### PR TITLE
Remove cluster config option and comments, fix pep8 issues

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -3,11 +3,6 @@
     "type": "string"
     "default": "cinder_netapp"
     "description": "Service name to present to Cinder"
-  "cluster-cinder-volume":
-    "type": "boolean"
-    "default": !!bool "false"
-    "description": |
-      Whether to handle all cinder-volume services as a cluster.
   "netapp-storage-family":
     "type": "string"
     "default": "ontap_cluster"

--- a/unit_tests/test_lib_charm_openstack_cinder_netapp.py
+++ b/unit_tests/test_lib_charm_openstack_cinder_netapp.py
@@ -49,11 +49,6 @@ class TestCinderNetAppCharm(test_utils.PatchHelper):
         self.assertEqual(config.get('volume_driver'),
                          'cinder.volume.drivers.netapp.common.NetAppDriver')
 
-    def test_cinder_cluster_config(self):
-        charm = self._patch_config_and_charm({'cluster-cinder-volume': True})
-        charm.cinder_configuration()
-        self.assertTrue(charm.stateless)
-
     def test_cinder_https(self):
         charm = self._patch_config_and_charm({'netapp-server-port': 443})
         config = charm.cinder_configuration()
@@ -91,9 +86,9 @@ class TestCinderNetAppCharm(test_utils.PatchHelper):
         charm = self._patch_config_and_charm(econfig)
         config = charm.cinder_configuration()
         self.assertIn(('netapp_pool_name_search_pattern',
-                         econfig['netapp-pool-name-search-pattern']), config)
+                       econfig['netapp-pool-name-search-pattern']), config)
         self.assertIn(('netapp_lun_space_reservation',
-                         'enabled'), config)
+                       'enabled'), config)
 
     def test_cinder_fc_options(self):
         econfig = {'netapp-pool-name-search-pattern': 'foo.*bar',
@@ -102,9 +97,9 @@ class TestCinderNetAppCharm(test_utils.PatchHelper):
         charm = self._patch_config_and_charm(econfig)
         config = charm.cinder_configuration()
         self.assertIn(('netapp_pool_name_search_pattern',
-                         econfig['netapp-pool-name-search-pattern']), config)
+                       econfig['netapp-pool-name-search-pattern']), config)
         self.assertIn(('netapp_lun_space_reservation',
-                         'enabled'), config)
+                       'enabled'), config)
 
     def test_cinder_iscsi_fc_options_not_included(self):
         econfig = {'netapp-pool-name-search-pattern': 'foo.*bar',


### PR DESCRIPTION
Upon further discussion with the NetApp driver team and in
light of [0] merging, the cluster-cinder-volume config has
become non-functional for the moment as the driver does not
support ACTIVE-ACTIVE [1] and the cinder code will not allow
the driver to start in a clustered mode without supporting
ACTIVE-ACTIVE [2].

[0] https://review.opendev.org/811472
[1] https://github.com/openstack/cinder/blob/93fb8fbe161f922a3cdafc402bab367ba91e318e/cinder/volume/driver.py#L391
[2] https://github.com/openstack/cinder/blob/93fb8fbe161f922a3cdafc402bab367ba91e318e/cinder/volume/manager.py#L313