### PR TITLE
Remove netapp-storage-pools config over netapp-pool-name-search-pattern

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -68,10 +68,6 @@
     "default": !!null ""
     "description": |
       Password for the NetApp E-Series storage array.
-  "netapp-storage-pools":
-    "type": "string"
-    "default": !!null ""
-    "description": "comma seperated list of pool names ie: pool1,pool2"
   "use-multipath":
     "type": "boolean"
     "default": !!bool "true"

--- a/src/lib/charm/openstack/cinder_netapp.py
+++ b/src/lib/charm/openstack/cinder_netapp.py
@@ -50,7 +50,10 @@ class CinderNetAppCharm(
             ('netapp_login', cget('netapp-login')),
             ('netapp_password', cget('netapp-password')),
             ('volume_driver', volumedriver),
-            ('volume_backend_name', service)]
+            ('volume_backend_name', service),
+            ('netapp_pool_name_search_pattern', cget(
+                'netapp-pool-name-search-pattern'))
+        ]
 
         if cget('netapp-server-port') == 443:
             driver_transport = [
@@ -60,7 +63,6 @@ class CinderNetAppCharm(
             driver_options_extension = [
                 ('netapp_controller_ips', cget('netapp-controller-ips')),
                 ('netapp_sa_password', cget('netapp-array-password')),
-                ('netapp_storage_pools', cget('netapp-storage-pools')),
                 ('use_multipath_for_image_xfer', cget('use-multipath'))]
 
         if cget('netapp-storage-protocol') == "nfs":
@@ -74,8 +76,6 @@ class CinderNetAppCharm(
             else:
                 lun_space_reservation = 'disabled'
             driver_options_extension += [
-                ('netapp_pool_name_search_pattern', cget(
-                    'netapp-pool-name-search-pattern')),
                 ('netapp_lun_space_reservation', lun_space_reservation)]
 
         return (driver_options_common + driver_transport +

--- a/unit_tests/test_lib_charm_openstack_cinder_netapp.py
+++ b/unit_tests/test_lib_charm_openstack_cinder_netapp.py
@@ -58,7 +58,7 @@ class TestCinderNetAppCharm(test_utils.PatchHelper):
         econfig = {'netapp-storage-family': 'eseries',
                    'netapp-controller-ips': '10.0.0.1',
                    'netapp-array-password': 'abc123',
-                   'netapp-storage-pools': 'somePool',
+                   'netapp-pool-name-search-pattern': 'foo.*bar',
                    'use-multipath': True}
         charm = self._patch_config_and_charm(econfig)
         config = charm.cinder_configuration()
@@ -66,8 +66,8 @@ class TestCinderNetAppCharm(test_utils.PatchHelper):
                        econfig['netapp-controller-ips']), config)
         self.assertIn(('netapp_sa_password',
                        econfig['netapp-array-password']), config)
-        self.assertIn(('netapp_storage_pools',
-                       econfig['netapp-storage-pools']), config)
+        self.assertIn(('netapp_pool_name_search_pattern',
+                       econfig['netapp-pool-name-search-pattern']), config)
         self.assertIn(('use_multipath_for_image_xfer',
                        econfig['use-multipath']), config)
         self.assertFalse(any(q[0] == 'nfs_shares_config' for q in config))
@@ -102,11 +102,8 @@ class TestCinderNetAppCharm(test_utils.PatchHelper):
                        'enabled'), config)
 
     def test_cinder_iscsi_fc_options_not_included(self):
-        econfig = {'netapp-pool-name-search-pattern': 'foo.*bar',
-                   'netapp-lun-space-reservation': True}
+        econfig = {'netapp-lun-space-reservation': True}
         charm = self._patch_config_and_charm(econfig)
         config = charm.cinder_configuration()
-        self.assertNotIn(('netapp_pool_name_search_pattern',
-                         econfig['netapp-pool-name-search-pattern']), config)
         self.assertNotIn(('netapp_lun_space_reservation',
                          'enabled'), config)


### PR DESCRIPTION
- The config option has been deprecated long time ago [0][1]
- netapp-pool-name-search-pattern is shared by ONTAP and E-series
- E-series always uses iSCSI protocol so the config
  netapp-pool-name-search-pattern should not be tied to the
  netapp-storage-protocol config

[0] https://github.com/openstack/cinder/blob/ab0313e3567e4ff8e5d6a2a678ad186df4fb7c5a/cinder/volume/drivers/netapp/options.py#L165
[1] https://github.com/openstack/cinder/blob/ab0313e3567e4ff8e5d6a2a678ad186df4fb7c5a/cinder/volume/drivers/netapp/eseries/library.py#L1692